### PR TITLE
Back hide on first search level

### DIFF
--- a/DigitalDoctor/app/src/main/java/com/juniordesign/digitaldoctor/SearchFragment.java
+++ b/DigitalDoctor/app/src/main/java/com/juniordesign/digitaldoctor/SearchFragment.java
@@ -118,6 +118,7 @@ public class SearchFragment extends Fragment {
 
                 if (level == 0) {
                     levelZeroBackHelper();
+                    back.setVisibility(View.INVISIBLE);
                 } else {
                     whereColumns.remove(whereColumns.size() - 1);
                     whereMatches.remove(whereMatches.size() - 1);
@@ -172,6 +173,7 @@ public class SearchFragment extends Fragment {
             resultsList.add(getResources().getString(R.string.pregnancy_symptoms));
             resultsList.add(getResources().getString(R.string.childhood_symptoms));
 
+            back.setVisibility(View.INVISIBLE);
 
         } else {
             setPromptText(level - 1, _tableName);
@@ -200,6 +202,7 @@ public class SearchFragment extends Fragment {
                 //searchDone - whether or not we reached the end of a search sequence
                 boolean searchDone = false;
                 if (level == 0) {
+                    back.setVisibility(View.VISIBLE);
                     switch (position) {
                         case 0:
                             //1 - Body-Part Specific Symptoms


### PR DESCRIPTION
Note this doesn't remove the functionality of the button, it simply hides it. However, since back has no functionality at the base level, this is essentially the same as removing it at level 0.